### PR TITLE
'testimonials' en 'tracks' tonen op de voorpagina

### DIFF
--- a/layouts/partials/testimonials/main-testimonials.html
+++ b/layouts/partials/testimonials/main-testimonials.html
@@ -1,5 +1,5 @@
  <div id="testimonials" class="container">
-    {{ $list := (where .Data.Pages "Section" "testimonials") }}
+    {{ $list := (where .Site.Pages "Section" "testimonials") }}
     <div id="carouselExampleIndicators" class="carousel slide" data-ride="carousel">
         <ol class="carousel-indicators">
             {{ range $index, $element := $list  }}

--- a/layouts/partials/tracks/main-tracks.html
+++ b/layouts/partials/tracks/main-tracks.html
@@ -1,7 +1,7 @@
 <section id="programma">
     <h1>Onze programma's</h1>
     <div>
-        {{ $list := (where (.Data.Pages.ByParam "order") "Section" "tracks") }}
+        {{ $list := (where (.Site.Pages.ByParam "order") "Section" "tracks") }}
         <ul class="nav nav-pills justify-content-center">
             {{ range $list }}
             <li class="nav-item {{ if eq .Params.order 0 }} active {{ end }}">


### PR DESCRIPTION
Dit werkt niet meer sinds https://github.com/TechTeachInfo/TechTeachInfo.github.io/commit/ff207cd5c50caf283426f09ddd8a18ae52fda0c2,
waarschijnlijk is er iets veranderd tussen Hugo 0.50 en Hugo 0.59

Dit werkt in ieder geval beter, hoewel er nog een tab teveel getoond wordt